### PR TITLE
Add GitHub Actions workflow for Expo CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,47 @@
+name: Expo CI
+
+on:
+  push:
+    branches:
+      - main
+      - master
+  pull_request:
+    branches:
+      - main
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: npm
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Run TypeScript check
+        run: npm run type-check --if-present
+
+      - name: Run ESLint
+        run: npm run lint --if-present
+
+      - name: Set up Expo
+        uses: expo/expo-github-action@v8
+        with:
+          expo-version: latest
+          token: ${{ secrets.EXPO_TOKEN }}
+
+      - name: Expo Doctor (checks project health)
+        run: npx expo doctor
+
+      - name: Build Expo project (Android)
+        run: |
+          npx expo export --platform android


### PR DESCRIPTION
This workflow sets up CI for Expo projects, including Node.js setup, dependency installation, TypeScript checks, ESLint, and building for Android.